### PR TITLE
Update jsmin-1.1.1.php resolve php 8.2 deprecations

### DIFF
--- a/src/jsmin-1.1.1.php
+++ b/src/jsmin-1.1.1.php
@@ -157,6 +157,7 @@ class JSMin {
   }
 
   protected function isAlphaNum($c) {
+    if($c === null) return false;
     return ord($c) > 126 || $c === '\\' || preg_match('/^[\w\$]$/', $c) === 1;
   }
 


### PR DESCRIPTION
Hi ✋, lib in php 8.2, drops deprecations.  This should solve the problem. 
Not sure about last line, maybe file ending changes 🤷‍♂️ 


```
notice: ord(): Passing null to parameter #1 ($character) of type string is deprecated Trace:
JSMin::isAlphaNum() /var/www/x/vendor/linkorb/jsmin-php/src/jsmin-1.1.1.php, line 160
```


